### PR TITLE
Capture `stdout` and `stderr` even if `cmd.Run` fails

### DIFF
--- a/fn.go
+++ b/fn.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"os/exec"
 	"strings"
 
 	"github.com/crossplane-contrib/function-shell/input/v1alpha1"
@@ -84,7 +86,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 		shellCmd = in.ShellCommandField
 	}
 
-	var shellEnvVars = make(map[string]string)
+	shellEnvVars := make(map[string]string)
 	for _, envVar := range in.ShellEnvVars {
 		if envVar.ValueRef != "" {
 			envValue, err := fromValueRef(req, envVar.ValueRef)
@@ -107,7 +109,7 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 	}
 
 	var exportCmds string
-	//exportCmds = "export PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin;"
+	// exportCmds = "export PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin;"
 	for k, v := range shellEnvVars {
 		exportCmds = exportCmds + "export " + k + "=\"" + v + "\";"
 	}
@@ -118,25 +120,32 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 	cmd := shell.Commandf(exportCmds + shellCmd)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	err = cmd.Run()
+
+	cmderr := cmd.Run()
+	sout := strings.TrimSpace(stdout.String())
+	serr := strings.TrimSpace(stderr.String())
+
+	log.Debug(shellCmd, "stdout", sout, "stderr", serr)
+
+	err = dxr.Resource.SetValue(stdoutField, sout)
 	if err != nil {
-		response.Fatal(rsp, errors.Wrapf(err, "shellCmd %s for %s failed", shellCmd, oxr.Resource.GetKind()))
+		response.Fatal(rsp, errors.Wrapf(err, "cannot set field %s to %s for %s", stdoutField, sout, oxr.Resource.GetKind()))
 		return rsp, nil
 	}
-	out := strings.TrimSpace(stdout.String())
-	err = dxr.Resource.SetValue(stdoutField, out)
+
+	err = dxr.Resource.SetValue(stderrField, serr)
 	if err != nil {
-		response.Fatal(rsp, errors.Wrapf(err, "cannot set field %s to %s for %s", stdoutField, out, oxr.Resource.GetKind()))
-		return rsp, nil
-	}
-	err = dxr.Resource.SetValue(stderrField, strings.TrimSpace(stderr.String()))
-	if err != nil {
-		response.Fatal(rsp, errors.Wrapf(err, "cannot set field %s to %s for %s", stderrField, out, oxr.Resource.GetKind()))
-		return rsp, nil
+		response.Fatal(rsp, errors.Wrapf(err, "cannot set field %s to %s for %s", stderrField, serr, oxr.Resource.GetKind()))
 	}
 	if err := response.SetDesiredCompositeResource(rsp, dxr); err != nil {
 		response.Fatal(rsp, errors.Wrapf(err, "cannot set desired composite resources from %T", req))
-		return rsp, nil
+	}
+
+	if cmderr != nil {
+		if exiterr, ok := cmderr.(*exec.ExitError); ok {
+			msg := fmt.Sprintf("shellCmd %q for %q failed with %s", shellCmd, oxr.Resource.GetKind(), exiterr.Stderr)
+			response.Fatal(rsp, errors.Wrap(cmderr, msg))
+		}
 	}
 
 	return rsp, nil


### PR DESCRIPTION
In its current form, if `cmd.Run` fails, then the function immediately exits with no reason given for the termination. This makes debugging scripts hard to understand as no indication is given for the failure, other than a failure occured.

By trapping the error returned from `cmd.Run`, we first process the buffers for both `stdout` and `stderr` and set these to the `dxr`.

Additionally we capture a truncated `stderr` from the command error which can help point to where the command failed, setting this as the Fatal error message returned as an event.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

# Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Fixes #

I have:

- [ ] Read and followed Crossplane's
[contribution process][contribution process]. Also see [docs][docs].
- [ ] Added or updated unit tests for my change.

[contribution process]: https://git.io/fj2m9
[docs]: https://docs.crossplane.io/contribute/contribute
